### PR TITLE
Fix for #4

### DIFF
--- a/libbiokanga/SAMfile.cpp
+++ b/libbiokanga/SAMfile.cpp
@@ -1685,7 +1685,7 @@ else
 // if generating a BAM file then need to add the sequence names 
 if(m_SAMFileType >= eSFTBAM)
 	{
-	m_CurBAMLen += sprintf((char *)&m_pBAM[m_CurBAMLen],"\n@PG\tID:%s\tVN:%s",gszProcName,m_szVer); 
+	m_CurBAMLen += sprintf((char *)&m_pBAM[m_CurBAMLen],"\n@PG\tID:%s\tVN:%s\n",gszProcName,m_szVer); 
 	*(UINT32 *)&m_pBAM[4] = (UINT32)(m_CurBAMLen - 8);
 	*(UINT32 *)&m_pBAM[m_CurBAMLen] = m_NumRefSeqNames;
 	m_CurBAMLen += 4;


### PR DESCRIPTION
Include a \n following the last line of the header. SAMtools doesn't correctly handle the absence of this.
Although it will be fixed in an upcomming release as discussed here: https://github.com/samtools/samtools/issues/661